### PR TITLE
Fix/whole word cv

### DIFF
--- a/lib_ml/preprocessing.py
+++ b/lib_ml/preprocessing.py
@@ -32,14 +32,11 @@ def _text_process(text: str):
     for stopword in ['not', 'but']:
         all_stopwords.remove(stopword)
     ps = PorterStemmer()
-
     review = re.sub('[^a-zA-Z]', ' ', text)
     review = review.lower()
     review = review.split()
     review = [ps.stem(word) for word in review if not word in set(all_stopwords)]
-    cln_review = ' '.join(review)
-    
-    return cln_review
+    return review
 
 def preprocess(path: Path):
     reviews = _load_data(path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lib_ml"
-version = "0.1.5"
+version = "0.1.6-beta"
 description = ""
 authors = [
     {name = "Nathan Blum",email = "n.blum@student.tudelft.nl"}


### PR DESCRIPTION
Fixed the preprocessor to pass whole words to the CountVectorizer instead of a string - the string ended up being split into characters, causing unexpected behaviour.

Added version v0.1.6b to test working status in model-training